### PR TITLE
Fixed highlighting menu item problem

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,19 +21,19 @@ class App extends Component {
         <Switch>
           <Route exact path={process.env.PUBLIC_URL + '/'} render = {props =>
             <div>
-              <Header />
+              <Header initialActiveItem={'search'}/>
               <Search />
             </div>
           } />
           <Route exact path={process.env.PUBLIC_URL + '/Compare'} render = {props =>
             <div>
-              <Header />
+              <Header initialActiveItem={'compare'}/>
               <Compare />
             </div>
           } />
           <Route exact path={process.env.PUBLIC_URL + '/User'} render = {props =>
             <div>
-              <Header />
+              <Header initialActiveItem={'user'}/>
               <User />
             </div>
           } />
@@ -44,13 +44,13 @@ class App extends Component {
           } />
           <Route exact path={process.env.PUBLIC_URL + '/Display'} render = {props =>
             <div>
-              <Header />
+              <Header initialActiveItem={'compare'}/>
               <User />
             </div>
           } />  
           <Route exact path={process.env.PUBLIC_URL + '/CompareDisplay'} render = {props =>
             <div>
-              <Header />
+              <Header initialActiveItem={'compare'}/>
               <User />
             </div>
           } />          

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,7 @@ class App extends Component {
           } />
           <Route exact path={process.env.PUBLIC_URL + '/Display'} render = {props =>
             <div>
-              <Header initialActiveItem={'compare'}/>
+              <Header initialActiveItem={'search'}/>
               <User />
             </div>
           } />  

--- a/src/Components/Header/Header.jsx
+++ b/src/Components/Header/Header.jsx
@@ -14,6 +14,12 @@ class Header extends Component {
     }
   }
 
+  componentDidMount() {
+    if (this.props.initialActiveItem) {
+      this.setState({activeItem: this.props.initialActiveItem});
+    }
+  }
+
   render() {
     const { activeItem } = this.state
 
@@ -66,5 +72,10 @@ class Header extends Component {
     )
   }
 }
+
+Header.defaultProps = {
+  // for when we navigate to another menu item from a url instead of clicking
+  initialActiveItem: 'search'
+};
 
 export default Header;


### PR DESCRIPTION
Going directly to a component like `/user` through the browser instead of navigating by clicking will result in "Search" being the initial active item in the menu.

This pull request fixes this issue.